### PR TITLE
Friend delete ability

### DIFF
--- a/client/components/friends/AllFriends.js
+++ b/client/components/friends/AllFriends.js
@@ -13,8 +13,11 @@ export class AllFriends extends React.Component {
     this.props.loadFriends(this.props.user.id)
   }
 
-  handleDelete = (friendToDelete) => {
-    this.props.deleteFriend(friendToDelete)
+  handleDelete = (userId, friendToDelete) => {
+    // console.log('user', userId)
+    // console.log('user', friendToDelete)
+
+    this.props.deleteFriend(userId, friendToDelete)
   }
 
   noFriends = (friendList) => {
@@ -25,6 +28,7 @@ export class AllFriends extends React.Component {
 
   render() {
     const friendList = this.props.friends
+    const user = this.props.user.id
     return (
       <div>
         <main>
@@ -48,9 +52,14 @@ export class AllFriends extends React.Component {
               return (
                 <div key={`friend-${friendItem.id}`}>
                   <Link to={`/friend/${friendItem.id}`}>
-                    {friendItem.firstName} {friendItem.lastName}{' '}
-                    {friendItem.email}
+                    {friendItem.firstName} {friendItem.lastName}
                   </Link>
+                  <button
+                    type="button"
+                    onClick={() => this.handleDelete(user, friendItem.id)}
+                  >
+                    Remove Friend Connection
+                  </button>
                 </div>
               )
             })}
@@ -70,7 +79,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   loadFriends: (userId) => dispatch(_loadFriends(userId)),
-  deleteFriend: (friend) => dispatch(_deleteFriend(friend)),
+  deleteFriend: (userId, friend) => dispatch(_deleteFriend(userId, friend)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(AllFriends)

--- a/client/components/friends/AllFriends.js
+++ b/client/components/friends/AllFriends.js
@@ -14,9 +14,6 @@ export class AllFriends extends React.Component {
   }
 
   handleDelete = (userId, friendToDelete) => {
-    // console.log('user', userId)
-    // console.log('user', friendToDelete)
-
     this.props.deleteFriend(userId, friendToDelete)
   }
 

--- a/client/store/friends/friends.js
+++ b/client/store/friends/friends.js
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import history from '../../history'
 import {ADD_FRIEND_SUCCESS, DELETE_FRIEND, GET_FRIENDS} from './friendTypes'
 import {
   addFriendError,
@@ -78,8 +77,7 @@ const friendsReducer = (friends = initialState, action) => {
     case DELETE_FRIEND:
       return [
         ...friends.filter(
-          (friend) =>
-            parseInt(friend.Friends.friendId) !== parseInt(action.friendId)
+          (friend) => parseInt(friend.id) !== parseInt(action.friendId)
         ),
       ]
     default:

--- a/server/api/friends.js
+++ b/server/api/friends.js
@@ -54,7 +54,7 @@ router.get('/:userId/:friendId', async (req, res, next) => {
     if (isNaN(friendId)) return res.sendStatus(404)
 
     const thisFriend = await User.findByPk(friendId, {
-      attributes: ['firstName', 'lastName', 'email'],
+      attributes: ['firstName', 'lastName', 'email', 'id'],
     })
     if (!thisFriend) return res.sendStatus(404)
 


### PR DESCRIPTION
* [ ] delete button beside each friend on the friend list view
* [ ] button deletes both front and back end friend connection (removes line from Friends table in db)
* [ ] removed email from friend list view so only a friend's name shows

Users should be able to remove friendship connections.

On full list view only name looks better than name and email. However, email still shows on single friend view to verify which friend in the event a user has more than one friend with the same name.


